### PR TITLE
desactivar restriccion gps ip

### DIFF
--- a/bff-datosasistencia/index.js
+++ b/bff-datosasistencia/index.js
@@ -41,6 +41,7 @@ app.post ('/datosasistenciageneral',async (req,res) =>{ // req/body.admin
 
 
       const agrupados = {};
+      console.log(result)
       result.forEach(dato => {
         const clave = dato.Ramo_Nombre;
         
@@ -50,13 +51,15 @@ app.post ('/datosasistenciageneral',async (req,res) =>{ // req/body.admin
         }
 
 
-        if(dato.Estado == "Ausente"){
-          agrupados[clave][0].Ausente++ 
-        }else{
-          agrupados[clave][0].Asistido++
+        if(dato.Asistido){
+          agrupados[clave][0].Asistido = dato.Asistido
+        }
+        if(dato.Inasistencia){
+          agrupados[clave][0].Ausente = dato.Inasistencia
         }
 
       });
+      console.log(resultasistencia)
       resultasistencia.forEach(dato => {
         const clave = dato.Ramo_Nombre;
         
@@ -66,10 +69,11 @@ app.post ('/datosasistenciageneral',async (req,res) =>{ // req/body.admin
         }
 
 
-        if(dato.Estado == "Ausente"){
-          agrupados[clave][0].Ausente++ 
-        }else{
-          agrupados[clave][0].Asistido++
+        if(dato.Asistido){
+          agrupados[clave][0].Asistido = dato.Asistido
+        }
+        if(dato.Inasistencia){
+          agrupados[clave][0].Ausente = dato.Inasistencia
         }
 
       });

--- a/ms-verificaciongps/index.js
+++ b/ms-verificaciongps/index.js
@@ -32,6 +32,9 @@ app.listen(PORT, () => {
 
 app.post('/verificar', async (req, res) => {
 
+  return res.status(200).json({validoIP: true,validoGPS: true}) // esto omitira la verificacion de ip/gps
+
+
     let validaIP = false
     let validaGPS = false
 
@@ -108,6 +111,8 @@ app.post('/verificar', async (req, res) => {
 
 app.post('/verificarIP',async (req,res) => {
 
+  return res.status(200).json({valido:true,ok:"valida la IP"}) // esto omitira la verificacion de ip
+  
   if(req.body.IP){
     const verificacionIP = new RegExp(ipValida[0]);
     if(verificacionIP.test(req.body.IP)){


### PR DESCRIPTION
se desactivaran las restricciones de ip y gps en la rama desarrollo pra activarlas tienen que borrar la linea de return rres.status... del microservicio de ms-verificaciongps

para las otras versiones mas avanzadas (rama QA y produccion) deberia estar restringidas